### PR TITLE
[FIX] Added cdn for material icons

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8"/>
     <link href="/cropped-i4n-icon-01-32x32.png" rel="icon"/>
+    <link href="https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css" rel="stylesheet"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>Invest4Nature</title>
 </head>

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cost-benefit-analyzer",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
The icons are breaking on dev env, the cdn needs to be added in the index.html for the icons to appear on dev